### PR TITLE
Hard-coded DNS servers in udhcpc busybox script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -524,6 +524,14 @@ RUN [ ! -f usr/local/etc/sshd_config ]; \
 	tcl-chroot adduser -S -G dockremap dockremap; \
 	echo 'dockremap:165536:65536' | tee etc/subuid | tee etc/subgid
 
+# udhcpc startup script modification with explicit DNS servers
+# respecting the default MAXNS=3 compile time constant
+RUN UDHCPC_SCRIPT="usr/share/udhcpc/default.script"; \
+	NS="echo nameserver"; \
+    SEARCH="$NS \$i"; \
+	sed -i "/$SEARCH/a $NS 8.8.8.8 >> \$RESOLV_CONF" "$UDHCPC_SCRIPT"; \
+	sed -i "/$SEARCH/a $NS 1.1.1.1 >> \$RESOLV_CONF" "$UDHCPC_SCRIPT"
+
 RUN savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This PR adds hard-coded fallback NS servers to the one provided to `udhcpc`.

What we know from JIRA:

> Sometimes (quite rarely, on non-deterministic basis) the following error occurs when Golem is building Docker images:
> ```
> DEBUG [golem.docker.commands.docker ] Docker command: ['docker', '-D', 'build', '-t', 'golemfactory/base', '-f', 'core/resources/images/base.Dockerfile', '.']
> DEBUG [golem.docker.commands.docker ] Docker command output: b'Sending build context to Docker daemon 38.41MB\r\r\nStep 1/10 : FROM debian:jessie\nGet https://registry-1.docker.io/v2/library/debian/manifests/jessie: Get https://auth.docker.io/token?scope=repository%3Alibrary%2Fdebian%3Apull&service=registry.docker.io: dial tcp: lookup auth.docker.io on 192.168.158.177:53: server misbehaving\n'
> ```
> 
> This is apparently caused by flaky DNS (I was using the default DNS in our office). Docker daemon should therefore be configured to use Google’s DNS 8.8.8.8 and 8.8.4.4.